### PR TITLE
Add close-to-all missing API functions

### DIFF
--- a/src/H5ACpublic.rs
+++ b/src/H5ACpublic.rs
@@ -1,0 +1,37 @@
+use libc::{c_char, c_int, c_long, c_double, size_t};
+use H5public::hbool_t;
+use H5Cpublic::{H5C_cache_incr_mode, H5C_cache_decr_mode, H5C_cache_flash_incr_mode};
+
+#[repr(C)]
+pub struct H5AC_cache_config_t {
+    version: c_int,
+    rpt_fcn_enabled: hbool_t,
+    open_trace_file: hbool_t,
+    close_trace_file: hbool_t,
+    trace_file_name: [c_char; 1025],
+    evictions_enabled: hbool_t,
+    set_initial_size: hbool_t,
+    initial_size: size_t,
+    min_clean_fraction: c_double,
+    max_size: size_t,
+    min_size: size_t,
+    epoch_length: c_long,
+    incr_mode: H5C_cache_incr_mode,
+    lower_hr_threshold: c_double,
+    increment: c_double,
+    apply_max_increment: hbool_t,
+    max_increment: size_t,
+    flash_incr_mode: H5C_cache_flash_incr_mode,
+    flash_multiple: c_double,
+    flash_threshold: c_double,
+    decr_mode: H5C_cache_decr_mode,
+    upper_hr_threshold: c_double,
+    decrement: c_double,
+    apply_max_decrement: hbool_t,
+    max_decrement: size_t,
+    epochs_before_eviction: c_int,
+    apply_empty_reserve: hbool_t,
+    empty_reserve: c_double,
+    dirty_bytes_threshold: c_int,
+    metadata_write_strategy: c_int,
+}

--- a/src/H5Apublic.rs
+++ b/src/H5Apublic.rs
@@ -1,0 +1,61 @@
+use libc::{c_char, c_void, size_t, ssize_t};
+use H5Ipublic::hid_t;
+use H5Opublic::H5O_msg_crt_idx_t;
+use H5Tpublic::H5T_cset_t;
+use H5public::{herr_t, htri_t, hsize_t, hbool_t, H5_index_t, H5_iter_order_t};
+
+#[repr(C)]
+pub struct H5A_info_t {
+    corder_valid: hbool_t,
+    corder: H5O_msg_crt_idx_t,
+    cset: H5T_cset_t,
+    data_size: hsize_t,
+}
+
+pub type H5A_operator2_t = extern fn(hid_t, *const c_char, *const H5A_info_t, *mut c_void) -> herr_t;
+
+extern "C" {
+    pub fn H5Acreate2(loc_id: hid_t, attr_name: *const c_char, type_id: hid_t, space_id: hid_t,
+                      acpl_id: hid_t, aapl_id: hid_t) -> hid_t;
+    pub fn H5Acreate_by_name(loc_id: hid_t, obj_name: *const c_char, attr_name: *const c_char,
+                             type_id: hid_t, space_id: hid_t, acpl_id: hid_t, aapl_id: hid_t,
+                             lapl_id: hid_t) -> hid_t;
+    pub fn H5Aopen(obj_id: hid_t, attr_name: *const c_char, aapl_id: hid_t) -> hid_t;
+    pub fn H5Aopen_by_name(loc_id: hid_t, obj_name: *const c_char, attr_name: *const c_char,
+                           aapl_id: hid_t, lapl_id: hid_t) -> hid_t;
+    pub fn H5Aopen_by_idx(loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t,
+                          order: H5_iter_order_t, n: hsize_t, aapl_id: hid_t, lapl_id: hid_t) -> hid_t;
+    pub fn H5Awrite(attr_id: hid_t, type_id: hid_t, buf: *const c_void) -> herr_t;
+    pub fn H5Aread(attr_id: hid_t, type_id: hid_t, buf: *mut c_void) -> herr_t;
+    pub fn H5Aclose(attr_id: hid_t) -> herr_t;
+    pub fn H5Aget_space(attr_id: hid_t) -> hid_t;
+    pub fn H5Aget_type(attr_id: hid_t) -> hid_t;
+    pub fn H5Aget_create_plist(attr_id: hid_t) -> hid_t;
+    pub fn H5Aget_name(attr_id: hid_t, buf_size: size_t, buf: *mut c_char) -> ssize_t;
+    pub fn H5Aget_name_by_idx(loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t,
+                              order: H5_iter_order_t, n: hsize_t, name: *mut c_char/*out*/, size: size_t,
+                              lapl_id: hid_t) -> ssize_t;
+    pub fn H5Aget_storage_size(attr_id: hid_t) -> hsize_t;
+    pub fn H5Aget_info(attr_id: hid_t, ainfo: *mut H5A_info_t/*out*/) -> herr_t;
+    pub fn H5Aget_info_by_name(loc_id: hid_t, obj_name: *const c_char, attr_name: *const c_char,
+                               ainfo: *mut H5A_info_t/*out*/, lapl_id: hid_t) -> herr_t;
+    pub fn H5Aget_info_by_idx(loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t,
+                              order: H5_iter_order_t, n: hsize_t, ainfo: *mut H5A_info_t/*out*/,
+                              lapl_id: hid_t) -> herr_t;
+    pub fn H5Arename(loc_id: hid_t, old_name: *const c_char, new_name: *const c_char) -> herr_t;
+    pub fn H5Arename_by_name(loc_id: hid_t, obj_name: *const c_char, old_attr_name: *const c_char,
+                             new_attr_name: *const c_char, lapl_id: hid_t) -> herr_t;
+    pub fn H5Aiterate2(loc_id: hid_t, idx_type: H5_index_t, order: H5_iter_order_t,
+                       idx: *mut hsize_t, op: H5A_operator2_t, op_data: *mut c_void) -> herr_t;
+    pub fn H5Aiterate_by_name(loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t,
+                              order: H5_iter_order_t, idx: *mut hsize_t, op: H5A_operator2_t,
+                              op_data: *mut c_void, lapd_id: hid_t) -> herr_t;
+    pub fn H5Adelete(loc_id: hid_t, name: *const c_char) -> herr_t;
+    pub fn H5Adelete_by_name(loc_id: hid_t, obj_name: *const c_char, attr_name: *const c_char,
+                             lapl_id: hid_t) -> herr_t;
+    pub fn H5Adelete_by_idx(loc_id: hid_t, obj_name: *const c_char, idx_type: H5_index_t, order:
+                            H5_iter_order_t, n: hsize_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Aexists(obj_id: hid_t, attr_name: *const c_char) -> htri_t;
+    pub fn H5Aexists_by_name(obj_id: hid_t, obj_name: *const c_char, attr_name: *const c_char,
+                             lapl_id: hid_t) -> htri_t;
+}

--- a/src/H5Cpublic.rs
+++ b/src/H5Cpublic.rs
@@ -1,0 +1,22 @@
+#[repr(C)]
+pub enum H5C_cache_incr_mode {
+    H5C_incr__off,
+    H5C_incr__threshold,
+}
+pub use self::H5C_cache_incr_mode::*;
+
+#[repr(C)]
+pub enum H5C_cache_flash_incr_mode {
+    H5C_flash_incr__off,
+    H5C_flash_incr__add_space,
+}
+pub use self::H5C_cache_flash_incr_mode::*;
+
+#[repr(C)]
+pub enum H5C_cache_decr_mode {
+    H5C_decr__off,
+    H5C_decr__threshold,
+    H5C_decr__age_out,
+    H5C_decr__age_out_with_threshold,
+}
+pub use self::H5C_cache_decr_mode::*;

--- a/src/H5Dpublic.rs
+++ b/src/H5Dpublic.rs
@@ -1,7 +1,11 @@
-use libc::{c_char, c_void};
+use libc::{c_char, c_uint, c_void, size_t};
 
 use H5Ipublic::hid_t;
-use H5public::{herr_t, hsize_t};
+use H5public::{herr_t, hsize_t, haddr_t};
+
+pub type H5D_operator_t = extern fn(*mut c_void, hid_t, c_uint, *const hsize_t, *mut c_void);
+pub type H5D_gather_func_t = extern fn(*const c_void, size_t, *mut c_void);
+pub type H5D_scatter_func_t = extern fn(*mut *const c_void, *mut size_t, *mut c_void);
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
@@ -14,15 +18,75 @@ pub enum H5D_layout_t {
 }
 pub use self::H5D_layout_t::*;
 
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5D_alloc_time_t {
+    H5D_ALLOC_TIME_ERROR = -1,
+    H5D_ALLOC_TIME_DEFAULT = 0,
+    H5D_ALLOC_TIME_EARLY = 1,
+    H5D_ALLOC_TIME_LATE = 2,
+    H5D_ALLOC_TIME_INCR = 3,
+}
+pub use self::H5D_alloc_time_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5D_space_status_t {
+    H5D_SPACE_STATUS_ERROR = -1,
+    H5D_SPACE_STATUS_NOT_ALLOCATED = 0,
+    H5D_SPACE_STATUS_PART_ALLOCATED = 1,
+    H5D_SPACE_STATUS_ALLOCATED = 2,
+}
+pub use self::H5D_space_status_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5D_fill_time_t {
+    H5D_FILL_TIME_ERROR = -1,
+    H5D_FILL_TIME_ALLOC = 0,
+    H5D_FILL_TIME_NEVER = 1,
+    H5D_FILL_TIME_IFSET = 2,
+}
+pub use self::H5D_fill_time_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5D_fill_value_t {
+    H5D_FILL_VALUE_ERROR = -1,
+    H5D_FILL_VALUE_UNDEFINED = 0,
+    H5D_FILL_VALUE_DEFAULT = 1,
+    H5D_FILL_VALUE_USER_DEFINED = 2,
+}
+pub use self::H5D_fill_value_t::*;
+
 extern "C" {
     pub fn H5Dcreate2(loc_id: hid_t, name: *const c_char, type_id: hid_t, space_id: hid_t,
                       lcpl_id: hid_t, dcpl_id: hid_t, dapl_id: hid_t) -> hid_t;
-
+    pub fn H5Dcreate_anon(loc_id: hid_t, type_id: hid_t, space_id: hid_t, dcpl_id: hid_t, dapl_id:
+                          hid_t) -> hid_t;
+    pub fn H5Dopen2(loc_id: hid_t, name: *const c_char, dapl_id: hid_t) -> hid_t;
     pub fn H5Dclose(dset_id: hid_t) -> herr_t;
     pub fn H5Dget_space(dset_id: hid_t) -> hid_t;
-
+    pub fn H5Dget_space_status(dset_id: hid_t, status: *mut H5D_space_status_t) -> herr_t;
+    pub fn H5Dget_type(dataset_id: hid_t) -> hid_t;
+    pub fn H5Dget_create_plist(dataset_id: hid_t) -> hid_t;
+    pub fn H5Dget_access_plist(dataset_id: hid_t) -> hid_t;
+    pub fn H5Dget_offset(dset_id: hid_t) -> haddr_t;
+    pub fn H5Dget_storage_size(dataset_id: hid_t) -> hsize_t;
+    pub fn H5Dvlen_get_buf_size(dataset_id: hid_t, type_id: hid_t, space_id: hid_t, size: *mut
+                                hsize_t) -> herr_t;
+    pub fn H5Dvlen_reclaim(type_id: hid_t, space_id: hid_t, plist_id: hid_t, buf: *const c_void) -> herr_t;
+    pub fn H5Dread(dataset_id: hid_t, mem_type_id: hid_t, mem_space_id: hid_t, file_space_id:
+                   hid_t, xfer_plist_id: hid_t, buf: *mut c_void) -> herr_t;
     pub fn H5Dwrite(dset_id: hid_t, mem_type_id: hid_t, mem_space_id: hid_t, file_space_id: hid_t,
                     plist_id: hid_t, buf: *const c_void) -> herr_t;
-
+    pub fn H5Dgather(src_space_id: hid_t, src_buf: *const c_void, type_id: hid_t, dst_buf_size:
+                     size_t, dst_buf: *mut c_void, op: H5D_gather_func_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Dscatter(op: H5D_scatter_func_t, op_data: *const c_void, type_id: hid_t, dst_space_id:
+                      hid_t, dst_buf: *mut c_void) -> herr_t;
+    pub fn H5Diterate(buf: *mut c_void, type_id: hid_t, space_id: hid_t, operator: H5D_operator_t,
+                      operator_data: *mut c_void);
     pub fn H5Dset_extent(dset_id: hid_t, size: *const hsize_t) -> herr_t;
+    pub fn H5Dfill(fill: *const c_void, fill_type_id: hid_t, buf: *mut c_void, buf_type_id: hid_t,
+                   space_id: hid_t) -> herr_t;
 }

--- a/src/H5Epublic.rs
+++ b/src/H5Epublic.rs
@@ -1,0 +1,80 @@
+use libc::{c_char, c_void, c_uint, size_t, ssize_t, FILE};
+
+use H5Ipublic::hid_t;
+use H5public::herr_t;
+
+pub type H5E_major_t = hid_t;
+pub type H5E_minor_t = hid_t;
+
+pub type H5E_walk1_t = extern fn (c_uint, *const H5E_error1_t, *const c_void);
+pub type H5E_walk2_t = extern fn (c_uint, *const H5E_error2_t, *const c_void);
+
+pub type H5E_auto1_t = extern fn(*const c_void);
+pub type H5E_auto2_t = extern fn(hid_t, *const c_void);
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5E_type_t {
+    H5E_MAJOR,
+    H5E_MINOR,
+}
+pub use self::H5E_type_t::*;
+
+#[repr(C)]
+pub struct H5E_error1_t {
+    maj_num: H5E_major_t,
+    min_num: H5E_minor_t,
+    func_name: *const c_char,
+    file_name: *const c_char,
+    line: c_uint,
+    desc: *const c_char,
+}
+
+#[repr(C)]
+pub struct H5E_error2_t {
+    cls_id: hid_t,
+    maj_num: hid_t,
+    min_num: hid_t,
+    line: c_uint,
+    func_name: *const c_char,
+    file_name: *const c_char,
+    desc: *const c_char,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5E_direction_t {
+    H5E_WALK_UPWARD = 0,
+    H5E_WALK_DOWNWARD = 1,
+}
+pub use self::H5E_direction_t::*;
+
+extern "C" {
+    pub fn H5Eauto_is_v2(estack_id: hid_t, is_tack: *mut c_uint) -> herr_t;
+    pub fn H5Eclear2(estack: hid_t) -> herr_t;
+    pub fn H5Eclose_msg(mesg_id: hid_t) -> herr_t;
+    pub fn H5Eclose_stack(estack_id: hid_t) -> herr_t;
+    pub fn H5Ecreate_msg(class: hid_t, msg_type: H5E_type_t, mesg: *const c_char) -> hid_t;
+    pub fn H5Ecreate_stack() -> hid_t;
+    pub fn H5Eget_auto2(estack_id: hid_t, func: *mut H5E_auto2_t, client_data:
+                        *mut c_void) -> herr_t;
+    pub fn H5Eget_class_name(class_id: hid_t, name: *const c_char, size:
+                             size_t) -> ssize_t;
+    pub fn H5Eget_current_stack() -> hid_t;
+    pub fn H5Eget_msg(mesg_id: hid_t, mesg_type: *mut H5E_type_t, mesg: *mut
+                      c_char, size: size_t) -> ssize_t;
+    pub fn H5Eget_num(estack_id: hid_t) -> ssize_t;
+    pub fn H5Epop(estack_id: hid_t, count: size_t) -> herr_t;
+    pub fn H5Eprint2(estack_id: hid_t, stream: *const FILE) -> herr_t;
+    pub fn H5Epush2(estack_id: hid_t, file: *const c_char, func: *const c_char,
+                    line: c_uint, maj_num: H5E_major_t, min_num: H5E_minor_t,
+                    msg: *const c_char, ...) -> herr_t;
+    pub fn H5Eregister_class(cls_name: *const c_char, lib_name: *const c_char,
+                             version: *const c_char) -> hid_t;
+    pub fn H5Eset_auto2(error_stack: hid_t, func: H5E_auto2_t,
+                        client_data: *const c_void) -> herr_t;
+    pub fn H5Eset_current_stack(estack_id: hid_t) -> herr_t;
+    pub fn H5Eunregister_class(class_id: hid_t) -> herr_t;
+    pub fn H5Ewalk2(estack_id: hid_t, direction: H5E_direction_t, func:
+                    H5E_walk2_t, client_data: *const c_void) -> herr_t;
+}

--- a/src/H5FDpublic.rs
+++ b/src/H5FDpublic.rs
@@ -1,0 +1,36 @@
+use libc::{c_void, size_t};
+use H5public::herr_t;
+use H5Fpublic::H5F_mem_t;
+
+pub type H5FD_mem_t = H5F_mem_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5FD_file_image_op_t {
+    H5FD_FILE_IMAGE_OP_NO_OP,
+    H5FD_FILE_IMAGE_OP_PROPERTY_LIST_SET,
+    H5FD_FILE_IMAGE_OP_PROPERTY_LIST_COPY,
+    H5FD_FILE_IMAGE_OP_PROPERTY_LIST_GET,
+    H5FD_FILE_IMAGE_OP_PROPERTY_LIST_CLOSE,
+    H5FD_FILE_IMAGE_OP_FILE_OPEN,
+    H5FD_FILE_IMAGE_OP_FILE_RESIZE,
+    H5FD_FILE_IMAGE_OP_FILE_CLOSE,
+}
+
+type H5FD_file_image_callbacks_image_malloc_func = extern fn(size_t, H5FD_file_image_op_t, *mut c_void) -> *const c_void;
+type H5FD_file_image_callbacks_image_memcpy_func = extern fn(*mut c_void, *const c_void, size_t, H5FD_file_image_op_t, udata: *mut c_void) -> *const c_void;
+type H5FD_file_image_callbacks_image_realloc_func = extern fn(*mut c_void, size_t, H5FD_file_image_op_t, *mut c_void) -> *const c_void;
+type H5FD_file_image_callbacks_image_free_func = extern fn(*mut c_void, H5FD_file_image_op_t, *mut c_void) -> herr_t;
+type H5FD_file_image_callbacks_udata_copy_func = extern fn(*mut c_void) -> *const c_void;
+type H5FD_file_image_callbacks_udata_free_func = extern fn(*mut c_void) -> herr_t;
+
+#[repr(C)]
+pub struct H5FD_file_image_callbacks_t {
+    image_malloc: H5FD_file_image_callbacks_image_malloc_func,
+    image_memcpy: H5FD_file_image_callbacks_image_memcpy_func,
+    image_realloc: H5FD_file_image_callbacks_image_realloc_func,
+    image_free: H5FD_file_image_callbacks_image_free_func,
+    udata_copy: H5FD_file_image_callbacks_udata_copy_func,
+    udata_free: H5FD_file_image_callbacks_udata_free_func,
+    udata: *const c_void,
+}

--- a/src/H5Fpublic.rs
+++ b/src/H5Fpublic.rs
@@ -1,7 +1,8 @@
-use libc::{c_char, c_uint};
+use libc::{c_void, c_char, c_int, c_uint, c_double, size_t, ssize_t};
 
 use H5Ipublic::hid_t;
-use H5public::herr_t;
+use H5public::{herr_t, hbool_t, hsize_t, hssize_t, htri_t, H5_ih_info_t};
+use H5ACpublic::H5AC_cache_config_t;
 
 pub const H5F_ACC_RDONLY: c_uint = 0x0000;
 pub const H5F_ACC_RDWR: c_uint = 0x0001;
@@ -10,10 +11,87 @@ pub const H5F_ACC_EXCL: c_uint = 0x0004;
 pub const H5F_ACC_DEBUG: c_uint = 0x0008;
 pub const H5F_ACC_CREAT: c_uint = 0x0010;
 
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5F_scope_t {
+    H5F_SCOPE_LOCAL = 0,
+    H5F_SCOPE_GLOBAL = 1,
+}
+pub use self::H5F_scope_t::*;
+
+#[repr(C)]
+struct H5F_info_sohm_t {
+    hdr_size: hsize_t,
+    msgs_info: H5_ih_info_t,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5F_close_degree_t {
+    H5F_CLOSE_DEFAULT = 0,
+    H5F_CLOSE_WEAK = 1,
+    H5F_CLOSE_SEMI = 2,
+    H5F_CLOSE_STRONG = 3,
+}
+pub use self::H5F_close_degree_t::*;
+
+#[repr(C)]
+pub struct H5F_info_t {
+    super_ext_size: hsize_t,
+    sohm: H5F_info_sohm_t,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5F_mem_t {
+    H5FD_MEM_NOLIST = -1,
+    H5FD_MEM_DEFAULT = 0,
+    H5FD_MEM_SUPER = 1,
+    H5FD_MEM_BTREE = 2,
+    H5FD_MEM_DRAW = 3,
+    H5FD_MEM_GHEAP = 4,
+    H5FD_MEM_LHEAP = 5,
+    H5FD_MEM_OHDR = 6,
+    H5FD_MEM_NTYPES,
+}
+pub use self::H5F_mem_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5F_libver_t {
+    H5F_LIBVER_EARLIEST,
+    H5F_LIBVER_LATEST,
+}
+pub use self::H5F_libver_t::*;
+
 extern "C" {
     pub fn H5Fcreate(filename: *const c_char, flags: c_uint, create_plist: hid_t,
                      access_plist: hid_t) -> hid_t;
-
     pub fn H5Fopen(filename: *const c_char, flags: c_uint, access_plist: hid_t) -> hid_t;
+    pub fn H5Fget_file_image(file_id: hid_t, buf_ptr: *const c_void, buf_len: *const size_t) -> ssize_t;
+    pub fn H5Freopen(file_id: hid_t) -> hid_t;
     pub fn H5Fclose(file_id: hid_t) -> herr_t;
+    pub fn H5Fflush(object_id: hid_t, scope: H5F_scope_t) -> herr_t;
+    pub fn H5Fis_hdf5(name: *const c_char) -> htri_t;
+    pub fn H5Fmount(loc_id: hid_t, name: *const c_char, child_id: hid_t, fmpl_id: hid_t) -> herr_t;
+    pub fn H5Funmount(loc_id: hid_t, name: *const c_char) -> herr_t;
+    pub fn H5Fget_vfd_handle(file_id: hid_t, fapl_id: hid_t, file_handle: *mut c_void) -> herr_t;
+    pub fn H5Fget_filesize(file_id: hid_t, size: *mut hsize_t) -> herr_t;
+    pub fn H5Fget_create_plist(file_id: hid_t) -> hid_t;
+    pub fn H5Fget_access_plist(file_id: hid_t) -> hid_t;
+    pub fn H5Fget_info(obj_id: hid_t, file_info: *mut H5F_info_t) -> herr_t;
+    pub fn H5Fget_intent(file_id: hid_t, intent: *mut c_uint) -> herr_t;
+    pub fn H5Fget_name(obj_id: hid_t, name: *mut c_char, size: size_t) -> ssize_t;
+    pub fn H5Fget_obj_count(file_id: hid_t, types: c_uint) -> ssize_t;
+    pub fn H5Fget_obj_ids(file_id: hid_t, types: c_uint, max_objs: size_t, obj_id_list: *mut hid_t) -> ssize_t;
+    pub fn H5Fget_freespace(file_id: hid_t) -> hssize_t;
+    pub fn H5Fclear_elink_file_cache(file_id: hid_t) -> herr_t;
+    pub fn H5Fset_mdc_config(file_id: hid_t, config_ptr: *const H5AC_cache_config_t) -> herr_t;
+    pub fn H5Fget_mdc_config(file_id: hid_t, config_ptr: *mut H5AC_cache_config_t) -> herr_t;
+    pub fn H5Fget_mdc_hit_rate(file_id: hid_t, hit_rate_ptr: *mut c_double) -> herr_t;
+    pub fn H5Freset_mdc_hit_rate_stats(file_id: hid_t) -> herr_t;
+    pub fn H5Fget_mdc_size(file_id: hid_t, max_size_ptr: *mut size_t, min_clean_size_ptr: *mut
+                           size_t, cur_size_ptr: *mut size_t, cur_num_entries_ptr: *mut c_int) -> herr_t;
+    pub fn H5Fset_mpi_atomicity(file_id: hid_t, flag: hbool_t) -> herr_t;
+    pub fn H5Fget_mpi_atomicity(file_id: hid_t, flag: *mut hbool_t) -> herr_t;
 }

--- a/src/H5Gpublic.rs
+++ b/src/H5Gpublic.rs
@@ -1,0 +1,36 @@
+use libc::c_char;
+use H5public::{herr_t, hsize_t, hbool_t, H5_index_t, H5_iter_order_t};
+use H5Ipublic::hid_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5G_storage_type_t {
+    H5G_STORAGE_TYPE_UNKNOWN = -1,
+    H5G_STORAGE_TYPE_SYMBOL_TABLE,
+    H5G_STORAGE_TYPE_COMPACT,
+    H5G_STORAGE_TYPE_DENSE,
+}
+pub use self::H5G_storage_type_t::*;
+
+#[repr(C)]
+pub struct H5G_info_t {
+    storage_type: H5G_storage_type_t,
+    nlinks: hsize_t,
+    max_corder: i64,
+    mounted: hbool_t,
+}
+
+extern "C" {
+    pub fn H5Gcreate2(loc_id: hid_t, name: *const c_char, lcpl_id: hid_t, gcpl_id: hid_t,
+                      gapl_id: hid_t) -> hid_t;
+    pub fn H5Gcreate_anon(loc_id: hid_t, gcpl_id: hid_t, gapl_id: hid_t) -> hid_t;
+    pub fn H5Gopen2(loc_id: hid_t, name: *const c_char, gapl_id: hid_t) -> hid_t;
+    pub fn H5Gclose(group_id: hid_t) -> herr_t;
+    pub fn H5Gget_info(group_id: hid_t, group_info: *mut H5G_info_t) -> herr_t;
+    pub fn H5Gget_info_by_name(loc_id: hid_t, group_name: *const c_char,
+                               group_info: *mut H5G_info_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Gget_create_plist(group_id: hid_t) -> hid_t;
+    pub fn H5Gget_info_by_idx(loc_id: hid_t, group_name: *const c_char, index_type: H5_index_t,
+                              order: H5_iter_order_t, n: hsize_t, group_info: *mut H5G_info_t,
+                              lapl_id: hid_t) -> herr_t;
+}

--- a/src/H5Ipublic.rs
+++ b/src/H5Ipublic.rs
@@ -1,3 +1,52 @@
-use libc::c_int;
+use libc::{c_int, c_uint, c_char, c_void, size_t, ssize_t};
+use H5public::{herr_t, htri_t, hbool_t, hsize_t};
 
 pub type hid_t = c_int;
+
+pub type H5I_search_func_t = extern fn (*const c_void, hid_t, *const c_void) -> c_int;
+pub type H5I_free_t = extern fn(*mut c_void) -> herr_t;
+
+#[repr(C)]
+pub enum H5I_type_t {
+    H5I_UNINIT = (-2),
+    H5I_BADID = (-1),
+    H5I_FILE = 1,
+    H5I_GROUP,
+    H5I_DATATYPE,
+    H5I_DATASPACE,
+    H5I_DATASET,
+    H5I_ATTR,
+    H5I_REFERENCE,
+    H5I_VFL,
+    H5I_GENPROP_CLS,
+    H5I_GENPROP_LST,
+    H5I_ERROR_CLASS,
+    H5I_ERROR_MSG,
+    H5I_ERROR_STACK,
+    H5I_NTYPES,
+}
+pub use self::H5I_type_t::*;
+
+extern "C" {
+    pub fn H5Iget_file_id(obj_id: hid_t) -> hid_t;
+    pub fn H5Iget_name(obj_id: hid_t, name: *mut c_char, size: size_t) -> ssize_t;
+    pub fn H5Iget_type(obj_id: hid_t) -> H5I_type_t;
+    pub fn H5Iobject_verify(id: hid_t, id_member_type: H5I_type_t) -> *mut c_void;
+    pub fn H5Iremove_verify(id: hid_t, id_member_type: H5I_type_t) -> *mut c_void;
+    pub fn H5Isearch(member_type: H5I_type_t, func: H5I_search_func_t,
+                     key: *const c_void) -> *mut c_void;
+    pub fn H5Iis_valid(obj_id: hid_t) -> htri_t;
+    pub fn H5Iget_ref(obj_id: hid_t) -> c_int;
+    pub fn H5Iinc_ref(obj_id: hid_t) -> c_int;
+    pub fn H5Idec_ref(obj_id: hid_t) -> c_int;
+    pub fn H5Iregister(member_type: H5I_type_t, object: *const c_void) -> hid_t;
+    pub fn H5Iregister_type(hash_size: size_t, reserved: c_uint,
+                            free_func: H5I_free_t) -> H5I_type_t;
+    pub fn H5Idestroy_type(member_type: H5I_type_t) -> herr_t;
+    pub fn H5Itype_exists(member_type: H5I_type_t) -> htri_t;
+    pub fn H5Iget_type_ref(member_type: H5I_type_t) -> c_int;
+    pub fn H5Idec_type_ref(member_type: H5I_type_t) -> c_int;
+    pub fn H5Iinc_type_ref(member_type: H5I_type_t) -> c_int;
+    pub fn H5Iclear_type(member_type: H5I_type_t, force: hbool_t) -> herr_t;
+    pub fn H5Inmembers(member_type: H5I_type_t, num_members: *mut hsize_t) -> herr_t;
+}

--- a/src/H5Lpublic.rs
+++ b/src/H5Lpublic.rs
@@ -1,9 +1,97 @@
-use libc::c_char;
+use libc::{c_char, c_int, c_uint, c_void, size_t, ssize_t};
 
 use H5Ipublic::hid_t;
-use H5public::{herr_t, htri_t};
+use H5Tpublic::H5T_cset_t;
+use H5public::{herr_t, htri_t, hbool_t, hsize_t, haddr_t, H5_index_t, H5_iter_order_t};
+
+pub type H5L_create_func_t = extern fn(*const c_char, hid_t, *const c_void, size_t, hid_t);
+pub type H5L_move_func_t = extern fn(*const c_char, hid_t, *const c_void, size_t);
+pub type H5L_copy_func_t = extern fn(*const c_char, hid_t, *const c_void, size_t);
+pub type H5L_traverse_func_t = extern fn(*const c_char, hid_t, *const c_void, size_t, hid_t);
+pub type H5L_delete_func_t = extern fn(*const c_char, hid_t, *const c_void, size_t, hid_t);
+pub type H5L_query_func_t = extern fn(*const c_char, *const c_void, size_t, *mut c_void, size_t);
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5L_type_t {
+    H5L_TYPE_ERROR = (-1),
+    H5L_TYPE_HARD = 0,
+    H5L_TYPE_SOFT = 1,
+    H5L_TYPE_EXTERNAL = 64,
+    H5L_TYPE_MAX = 255,
+}
+pub use self::H5L_type_t::*;
+
+#[repr(C)]
+pub struct H5L_info_t {
+    link_type: H5L_type_t,
+    corder_valid: hbool_t,
+    corder: i64,
+    cset: H5T_cset_t,
+    address: haddr_t,  // TODO: Should be a haddr_t/size_t union (address/val_size)
+}
+
+#[repr(C)]
+pub struct H5L_class_t {
+    version: c_int,
+    id: H5L_type_t,
+    comment: *const c_char,
+    create_func: H5L_create_func_t,
+    move_func: H5L_move_func_t,
+    copy_func: H5L_copy_func_t,
+    trav_func: H5L_traverse_func_t,
+    del_func: H5L_delete_func_t,
+    query_func: H5L_query_func_t,
+}
+
+pub type H5L_iterate_t = extern fn(hid_t, *const c_char, *const H5L_info_t, *mut c_void);
+pub type H5L_elink_traverse_t = extern fn(*const c_char, *const c_char, *const c_char,
+                                          *const c_char, *mut c_uint, hid_t, *mut c_void);
 
 extern "C" {
-    pub fn H5Ldelete(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lcreate_hard(obj_loc_id: hid_t, obj_name: *const c_char, link_loc_id: hid_t,
+                          link_name: *const c_char, lcpl_id: hid_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lcreate_soft(target_path: *const c_char, link_loc_id: hid_t, link_name: *const c_char,
+                          lcpl_id: hid_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lcreate_external(target_file_name: *const c_char, target_obj_name: *const c_char,
+                              link_loc_id: hid_t, link_name: *const c_char, lcpl_id: hid_t,
+                              lapl_id: hid_t) -> herr_t;
     pub fn H5Lexists(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> htri_t;
+    pub fn H5Lmove(src_loc_id: hid_t, src_name: *const c_char, dest_loc_id: hid_t,
+                   dest_name: *const c_char, lcpl_id: hid_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lcopy(src_loc_id: hid_t, src_name: *const c_char, dest_loc_id: hid_t,
+                   dest_name: *const c_char, lcpl_id: hid_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Ldelete(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lget_info(link_loc_id: hid_t, link_name: *const c_char, link_buff: *mut H5L_info_t,
+                       lapl_id: hid_t) -> herr_t;
+    pub fn H5Lget_val(link_loc_id: hid_t, link_name: *const c_char, linkval_buff: *mut c_void,
+                      size: size_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lunpack_elink_val(ext_linkval: *const c_char, link_size: size_t, flags: *mut c_uint,
+                               filename: *mut *const c_char, obj_path: *mut *const c_char) -> herr_t;
+    pub fn H5Lcreate_ud(link_loc_id: hid_t, link_name: *const c_char, link_type: H5L_type_t,
+                        udata: *const c_char, udata_size: size_t, lcpl_id: hid_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Lregister(link_class: *const H5L_class_t) -> herr_t;
+    pub fn H5Lunregister(link_cls_id: H5L_type_t) -> herr_t;
+    pub fn H5Lis_registered(link_cls_id: H5L_type_t) -> htri_t;
+    pub fn H5Literate(group_id: hid_t, index_type: H5_index_t, order: H5_iter_order_t,
+                      idx: *mut hsize_t, op: H5L_iterate_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Literate_by_name(loc_id: hid_t, group_name: *const c_char, index_type: H5_index_t,
+                              order: H5_iter_order_t, idx: *mut hsize_t, op: H5L_iterate_t,
+                              op_data: *const c_void, lapl_id: *const hid_t) -> herr_t;
+    pub fn H5Lvisit(group_id: hid_t, index_type: H5_index_t, order: H5_iter_order_t,
+                    op: H5L_iterate_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Lvisit_by_name(loc_id: hid_t, group_name: *const c_char, index_type: H5_index_t,
+                            order: H5_iter_order_t, op: H5L_iterate_t, op_data: *const c_void,
+                            lapl_id: hid_t) -> herr_t;
+    pub fn H5Lget_info_by_idx(loc_id: hid_t, group_name: *const c_char, index_field: H5_index_t,
+                              order: H5_iter_order_t, n: hsize_t, link_val: *mut H5L_info_t,
+                              lapl_id: hid_t) -> herr_t;
+    pub fn H5Lget_name_by_idx(loc_id: hid_t, group_name: *const c_char, index_field: H5_index_t,
+                              order: H5_iter_order_t, n: hsize_t, name: *mut c_char, size: size_t,
+                              lapl_id: hid_t) -> ssize_t;
+    pub fn H5Lget_val_by_idx(loc_id: hid_t, group_name: *const c_char, index_type: H5_index_t,
+                             order: H5_iter_order_t, n: hsize_t, link_val: *mut c_void,
+                             size: size_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Ldelete_by_idx(loc_id: hid_t, group_name: *const c_char, index_field: H5_index_t,
+                            order: H5_iter_order_t, n: hsize_t, lapl_id: hid_t) -> herr_t;
 }

--- a/src/H5MMpublic.rs
+++ b/src/H5MMpublic.rs
@@ -1,0 +1,4 @@
+use libc::{c_void, size_t};
+
+pub type H5MM_allocate_t = extern fn(size_t, *mut c_void) -> *const c_void;
+pub type H5MM_free_t = extern fn(*mut c_void, *mut c_void);

--- a/src/H5Opublic.rs
+++ b/src/H5Opublic.rs
@@ -1,0 +1,103 @@
+use libc::{c_char, c_uint, c_ulong, c_void, size_t, ssize_t, time_t};
+use H5public::{herr_t, htri_t, hsize_t, haddr_t, H5_index_t, H5_iter_order_t, H5_ih_info_t};
+use H5Ipublic::hid_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5O_type_t {
+    H5O_TYPE_UNKNOWN = -1,
+    H5O_TYPE_GROUP,
+    H5O_TYPE_DATASET,
+    H5O_TYPE_NAMED_DATATYPE,
+    H5O_TYPE_NTYPES,
+}
+pub use self::H5O_type_t::*;
+
+#[repr(C)]
+struct H5O_hdr_info_space_t {
+    total: hsize_t,
+    meta: hsize_t,
+    mesg: hsize_t,
+    free: hsize_t,
+}
+
+#[repr(C)]
+struct H5O_hdr_info_mesg_t {
+    present: u64,
+    shared: u64,
+}
+
+#[repr(C)]
+pub struct H5O_hdr_info_t {
+    version: c_uint,
+    nmesgs: c_uint,
+    nchunks: c_uint,
+    flags: c_uint,
+    space: H5O_hdr_info_space_t,
+    mesg: H5O_hdr_info_mesg_t,
+}
+
+#[repr(C)]
+struct H5O_info_meta_size_t {
+    obj: H5_ih_info_t,
+    attr: H5_ih_info_t,
+}
+
+#[repr(C)]
+pub struct H5O_info_t {
+    fileno: c_ulong,
+    addr: haddr_t,
+    info_type: H5O_type_t,
+    rc: c_uint,
+    atime: time_t,
+    mtime: time_t,
+    ctime: time_t,
+    btime: time_t,
+    num_attrs: hsize_t,
+    hdr: H5O_hdr_info_t,
+    meta_size: H5O_info_meta_size_t,
+}
+
+pub type H5O_msg_crt_idx_t = u32;
+
+pub type H5O_iterate_t = extern fn(hid_t, *const c_char, *const H5O_info_t, *mut c_void) -> herr_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5O_mcdt_search_ret_t {
+    H5O_MCDT_SEARCH_ERROR = -1,
+    H5O_MCDT_SEARCH_CONT,
+    H5O_MCDT_SEARCH_STOP,
+}
+pub use self::H5O_mcdt_search_cb_t::*;
+
+pub type H5O_mcdt_search_cb_t = extern fn(*mut c_void) -> H5O_mcdt_search_ret_t;
+
+extern "C" {
+    pub fn H5Oopen(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> hid_t;
+    pub fn H5Oopen_by_idx(loc_id: hid_t, group_name: *const c_char, index_type: H5_index_t,
+                          order: H5_iter_order_t, n: hsize_t, lapl_id: hid_t) -> hid_t;
+    pub fn H5Oopen_by_addr(loc_id: hid_t, addr: haddr_t) -> hid_t;
+    pub fn H5Olink(object_id: hid_t, new_loc_id: hid_t, new_link_name: *const c_char,
+                   lcpl: hid_t, lapl: hid_t) -> herr_t;
+    pub fn H5Oclose(object_id: hid_t) -> herr_t;
+    pub fn H5Ocopy(src_loc_id: hid_t, src_name: *const c_char, dst_loc_id: hid_t,
+                   dst_name: *const c_char, ocpypl_id: hid_t, lcpl_id: hid_t) -> herr_t;
+    pub fn H5Ovisit(object_id: hid_t, index_type: H5_index_t, order: H5_iter_order_t,
+                    op: H5O_iterate_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Ovisit_by_name(loc_id: hid_t, object_name: *const c_char, index_type: H5_index_t,
+                            order: H5_iter_order_t, op: H5O_iterate_t, op_data: *const c_void,
+                            lapl_id: hid_t) -> herr_t;
+    pub fn H5Oget_comment(object_id: hid_t, comment: *mut c_char, bufsize: size_t) -> ssize_t;
+    pub fn H5Oget_comment_by_name(loc_id: hid_t, name: *const c_char, comment: *mut c_char,
+                                  bufsize: size_t, lapl_id: hid_t) -> ssize_t;
+    pub fn H5Oexists_by_name(loc_id: hid_t, name: *const c_char, lapl_id: hid_t) -> htri_t;
+    pub fn H5Oget_info(object_id: hid_t, object_info: *mut H5O_info_t) -> herr_t;
+    pub fn H5Oget_info_by_name(loc_id: hid_t, object_name: *const c_char,
+                               object_info: *mut H5O_info_t, lapl_id: hid_t) -> herr_t;
+    pub fn H5Oget_info_by_idx(loc_id: hid_t, group_name: *const c_char, index_field: H5_index_t,
+                              order: H5_iter_order_t, n: hsize_t, object_info: *mut H5O_info_t,
+                              lapl_id: hid_t) -> herr_t;
+    pub fn H5Oincr_refcount(object_id: hid_t) -> herr_t;
+    pub fn H5Odecr_refcount(object_id: hid_t) -> herr_t;
+}

--- a/src/H5PLpublic.rs
+++ b/src/H5PLpublic.rs
@@ -1,0 +1,7 @@
+use libc::c_int;
+use H5public::herr_t;
+
+extern "C" {
+    pub fn H5PLset_loading_state(plugin_flags: c_int) -> herr_t;
+    pub fn H5PLget_loading_state(plugin_flags: *mut c_int) -> herr_t;
+}

--- a/src/H5Ppublic.rs
+++ b/src/H5Ppublic.rs
@@ -1,17 +1,18 @@
-use libc::c_int;
+use libc::{c_char, c_int, c_uint, c_void, c_double, off_t, size_t, ssize_t};
 
-use H5Dpublic::H5D_layout_t;
+use H5Dpublic::{H5D_layout_t, H5D_fill_value_t, H5D_alloc_time_t, H5D_fill_time_t};
+use H5Fpublic::{H5F_close_degree_t, H5F_libver_t};
 use H5Ipublic::hid_t;
-use H5public::{herr_t, hsize_t};
+use H5Lpublic::H5L_elink_traverse_t;
+use H5Opublic::H5O_mcdt_search_cb_t;
+use H5Tpublic::{H5T_conv_except_func_t, H5T_cset_t};
+use H5Zpublic::{H5Z_filter_t, H5Z_SO_scale_type_t, H5Z_EDC_t, H5Z_filter_func_t};
+use H5FDpublic::{H5FD_mem_t, H5FD_file_image_callbacks_t};
+use H5ACpublic::H5AC_cache_config_t;
+use H5MMpublic::{H5MM_allocate_t, H5MM_free_t};
+use H5public::{herr_t, htri_t, hsize_t, hbool_t};
 
 pub const H5P_DEFAULT: hid_t = 0;
-
-extern "C" {
-    pub fn H5Pcreate(cls_id: hid_t) -> hid_t;
-    pub fn H5Pclose(plist_id: hid_t) -> herr_t;
-    pub fn H5Pset_layout(plist_id: hid_t, layout: H5D_layout_t) -> herr_t;
-    pub fn H5Pset_chunk(plist_id: hid_t, ndims: c_int, dim: *const hsize_t) -> herr_t;
-}
 
 extern "C" {
     pub static H5P_CLS_ROOT_ID_g: hid_t;
@@ -50,3 +51,235 @@ pub use self::H5P_CLS_ATTRIBUTE_CREATE_ID_g as H5P_ATTRIBUTE_CREATE;
 pub use self::H5P_CLS_OBJECT_COPY_ID_g as H5P_OBJECT_COPY;
 pub use self::H5P_CLS_LINK_CREATE_ID_g as H5P_LINK_CREATE;
 pub use self::H5P_CLS_LINK_ACCESS_ID_g as H5P_LINK_ACCESS;
+
+pub type H5P_cls_create_func_t = extern fn(hid_t, *mut c_void) -> herr_t;
+pub type H5P_cls_copy_func_t = extern fn(hid_t, hid_t, *mut c_void) -> herr_t;
+pub type H5P_cls_close_func_t = extern fn(hid_t, *mut c_void) -> herr_t;
+
+pub type H5P_prp_cb1_t = extern fn(*const c_char, size_t, *mut c_void) -> herr_t;
+pub type H5P_prp_cb2_t = extern fn(hid_t, *const c_char, size_t, *mut c_void) -> herr_t;
+pub type H5P_prp_create_func_t = H5P_prp_cb1_t;
+pub type H5P_prp_set_func_t = H5P_prp_cb2_t;
+pub type H5P_prp_get_func_t = H5P_prp_cb2_t;
+pub type H5P_prp_delete_func_t = H5P_prp_cb2_t;
+pub type H5P_prp_copy_func_t = H5P_prp_cb1_t;
+pub type H5P_prp_compare_func_t = extern fn(*const c_void, *const c_void, size_t) -> c_int;
+pub type H5P_prp_close_func_t = H5P_prp_cb1_t;
+
+pub type H5P_iterate_t = extern fn(hid_t, *const c_char, *mut c_void) -> herr_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5D_mpio_actual_chunk_opt_mode_t {
+    H5D_MPIO_NO_CHUNK_OPTIMIZATION = 0,
+    H5D_MPIO_LINK_CHUNK,
+    H5D_MPIO_MULTI_CHUNK,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5D_mpio_actual_io_mode_t {
+    H5D_MPIO_NO_COLLECTIVE = 0x0,
+    H5D_MPIO_CHUNK_INDEPENDENT = 0x1,
+    H5D_MPIO_CHUNK_COLLECTIVE = 0x2,
+    H5D_MPIO_CHUNK_MIXED = 0x1 | 0x2,
+    H5D_MPIO_CONTIGUOUS_COLLECTIVE = 0x4,
+}
+
+extern "C" {
+    pub fn H5Pcreate_class(parent: hid_t, name: *const c_char, cls_create: H5P_cls_create_func_t,
+                           create_data: *const c_void, cls_copy: H5P_cls_copy_func_t,
+                           copy_data: *const c_void, cls_close: H5P_cls_close_func_t,
+                           close_data: *const c_void) -> hid_t;
+    pub fn H5Pget_class_name(pclass_id: hid_t) -> *const c_char;
+    pub fn H5Pcreate(cls_id: hid_t) -> hid_t;
+    pub fn H5Pregister2(cls_id: hid_t, name: *const c_char, size: size_t, def_value: *const c_void,
+                        prp_create: H5P_prp_create_func_t, prp_set: H5P_prp_set_func_t,
+                        prp_get: H5P_prp_get_func_t, prp_del: H5P_prp_delete_func_t,
+                        prp_copy: H5P_prp_copy_func_t, prp_cmp: H5P_prp_compare_func_t,
+                        prp_close: H5P_prp_close_func_t) -> herr_t;
+    pub fn H5Pinsert2(plist_id: hid_t, name: *const c_char, size: size_t, value: *const c_void,
+                      prp_set: H5P_prp_set_func_t, prp_get: H5P_prp_get_func_t,
+                      prp_delete: H5P_prp_delete_func_t, prp_copy: H5P_prp_copy_func_t,
+                      prp_cmp: H5P_prp_compare_func_t, prp_close: H5P_prp_close_func_t) -> herr_t;
+    pub fn H5Pset(plist_id: hid_t, name: *const c_char, value: *const c_void) -> herr_t;
+    pub fn H5Pexist(plist_id: hid_t, name: *const c_char) -> htri_t;
+    pub fn H5Pget_size(id: hid_t, name: *const c_char, size: *mut size_t) -> herr_t;
+    pub fn H5Pget_nprops(id: hid_t, nprops: *mut size_t) -> herr_t;
+    pub fn H5Pget_class(plist_id: hid_t) -> hid_t;
+    pub fn H5Pget_class_parent(pclass_id: hid_t) -> hid_t;
+    pub fn H5Pget(plist_id: hid_t, name: *const c_char, value: *mut c_void) -> herr_t;
+    pub fn H5Pequal(id1: hid_t, id2: hid_t) -> htri_t;
+    pub fn H5Pisa_class(plist_id: hid_t, pclass_id: hid_t) -> htri_t;
+    pub fn H5Piterate(id: hid_t, idx: *mut c_int, iter_func: H5P_iterate_t,
+                      iter_data: *mut c_void) -> c_int;
+    pub fn H5Pcopy_prop(dst_id: hid_t, src_id: hid_t, name: *const c_char) -> herr_t;
+    pub fn H5Premove(plist_id: hid_t, name: *const c_char) -> herr_t;
+    pub fn H5Punregister(pclass_id: hid_t, name: *const c_char) -> herr_t;
+    pub fn H5Pclose_class(plist_id: hid_t) -> herr_t;
+    pub fn H5Pclose(plist_id: hid_t) -> herr_t;
+    pub fn H5Pcopy(plist_id: hid_t) -> hid_t;
+    pub fn H5Pset_attr_phase_change(plist_id: hid_t, max_compact: c_uint,
+                                    min_dense: c_uint) -> herr_t;
+    pub fn H5Pget_attr_phase_change(plist_id: hid_t, max_compact: *mut c_uint,
+                                    min_dense: *mut c_uint) -> herr_t;
+    pub fn H5Pset_attr_creation_order(plist_id: hid_t, crt_order_flags: c_uint) -> herr_t;
+    pub fn H5Pget_attr_creation_order(plist_id: hid_t, crt_order_flags: *mut c_uint) -> herr_t;
+    pub fn H5Pset_obj_track_times(plist_id: hid_t, track_times: hbool_t) -> herr_t;
+    pub fn H5Pget_obj_track_times(plist_id: hid_t, track_times: *mut hbool_t) -> herr_t;
+    pub fn H5Pmodify_filter(plist_id: hid_t, filter: H5Z_filter_t, flags: c_uint, cd_nelmts: size_t,
+                            cd_values: *const c_uint) -> herr_t;
+    pub fn H5Pset_filter(plist_id: hid_t, filter: H5Z_filter_t, flags: c_uint, cd_nelmts: size_t,
+                         c_values: *const c_uint) -> herr_t;
+    pub fn H5Pget_nfilters(plist_id: hid_t) -> c_int;
+    pub fn H5Pget_filter2(plist_id: hid_t, filter: c_uint, flags: *mut c_uint/*out*/,
+                          cd_nelmts: *mut size_t/*out*/, cd_values: *mut c_uint/*out*/,
+                          namelen: size_t, name: *mut c_char,
+                          filter_config: *mut c_uint/*out*/) -> H5Z_filter_t;
+    pub fn H5Pget_filter_by_id2(plist_id: hid_t, id: H5Z_filter_t, flags: *mut c_uint/*out*/,
+                                cd_nelmts: *mut size_t/*out*/, cd_values: *mut c_uint/*out*/,
+                                namelen: size_t, name: *mut c_char/*out*/,
+                                filter_config: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pall_filters_avail(plist_id: hid_t) -> htri_t;
+    pub fn H5Premove_filter(plist_id: hid_t, filter: H5Z_filter_t) -> herr_t;
+    pub fn H5Pset_deflate(plist_id: hid_t, aggression: c_uint) -> herr_t;
+    pub fn H5Pset_fletcher32(plist_id: hid_t) -> herr_t;
+    pub fn H5Pget_version(plist_id: hid_t, boot: *mut c_uint/*out*/, freelist: *mut c_uint/*out*/,
+                          stab: *mut c_uint/*out*/, shhdr: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pset_userblock(plist_id: hid_t, size: hsize_t) -> herr_t;
+    pub fn H5Pget_userblock(plist_id: hid_t, size: *mut hsize_t) -> herr_t;
+    pub fn H5Pset_sizes(plist_id: hid_t, sizeof_addr: size_t, sizeof_size: size_t) -> herr_t;
+    pub fn H5Pget_sizes(plist_id: hid_t, sizeof_addr: *mut size_t/*out*/, sizeof_size: *mut size_t/*out*/) -> herr_t;
+    pub fn H5Pset_sym_k(plist_id: hid_t, ik: c_uint, lk: c_uint) -> herr_t;
+    pub fn H5Pget_sym_k(plist_id: hid_t, ik: *mut c_uint/*out*/, lk: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pset_istore_k(plist_id: hid_t, ik: c_uint) -> herr_t;
+    pub fn H5Pget_istore_k(plist_id: hid_t, ik: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pset_shared_mesg_nindexes(plist_id: hid_t, nindexes: c_uint) -> herr_t;
+    pub fn H5Pget_shared_mesg_nindexes(plist_id: hid_t, nindexes: *mut c_uint) -> herr_t;
+    pub fn H5Pset_shared_mesg_index(plist_id: hid_t, index_num: c_uint, mesg_type_flags: c_uint,
+                                    min_mesg_size: c_uint) -> herr_t;
+    pub fn H5Pget_shared_mesg_index(plist_id: hid_t, index_num: c_uint, mesg_type_flags: *mut c_uint,
+                                    min_mesg_size: *mut c_uint) -> herr_t;
+    pub fn H5Pset_shared_mesg_phase_change(plist_id: hid_t, max_list: c_uint, min_btree: c_uint) -> herr_t;
+    pub fn H5Pget_shared_mesg_phase_change(plist_id: hid_t, max_list: *mut c_uint,
+                                           min_btree: *mut c_uint) -> herr_t;
+    pub fn H5Pset_alignment(fapl_id: hid_t, threshold: hsize_t, alignment: hsize_t) -> herr_t;
+    pub fn H5Pget_alignment(fapl_id: hid_t, threshold: *mut hsize_t/*out*/,
+                            alignment: *mut hsize_t/*out*/) -> herr_t;
+    pub fn H5Pset_driver(plist_id: hid_t, driver_id: hid_t, driver_info: *const c_void) -> herr_t;
+    pub fn H5Pget_driver(plist_id: hid_t) -> hid_t;
+    pub fn H5Pget_driver_info(plist_id: hid_t) -> *const c_void;
+    pub fn H5Pset_family_offset(fapl_id: hid_t, offset: hsize_t) -> herr_t;
+    pub fn H5Pget_family_offset(fapl_id: hid_t, offset: *mut hsize_t) -> herr_t;
+    pub fn H5Pset_multi_type(fapl_id: hid_t, data_type: H5FD_mem_t) -> herr_t;
+    pub fn H5Pget_multi_type(fapl_id: hid_t, data_type: *mut H5FD_mem_t) -> herr_t;
+    pub fn H5Pset_cache(plist_id: hid_t, mdc_nelmts: c_int, rdcc_nslots: size_t, rdcc_nbytes: size_t,
+                        rdcc_w0: c_double) -> herr_t;
+    pub fn H5Pget_cache(plist_id: hid_t, mdc_nelmts: *mut c_int/*out*/, rdcc_nslots: *mut size_t/*out*/,
+                        rdcc_nbytes: *mut size_t/*out*/, rdcc_w0: *mut c_double) -> herr_t;
+    pub fn H5Pset_mdc_config(plist_id: hid_t, config_ptr: *mut H5AC_cache_config_t) -> herr_t;
+    pub fn H5Pget_mdc_config(plist_id: hid_t, config_ptr: *const H5AC_cache_config_t) -> herr_t;
+    pub fn H5Pset_gc_references(fapl_id: hid_t, gc_ref: c_uint) -> herr_t;
+    pub fn H5Pget_gc_references(fapl_id: hid_t, gc_ref: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pset_fclose_degree(fapl_id: hid_t, degree: H5F_close_degree_t) -> herr_t;
+    pub fn H5Pget_fclose_degree(fapl_id: hid_t, degree: *mut H5F_close_degree_t) -> herr_t;
+    pub fn H5Pset_meta_block_size(fapl_id: hid_t, size: hsize_t) -> herr_t;
+    pub fn H5Pget_meta_block_size(fapl_id: hid_t, size: *mut hsize_t/*out*/) -> herr_t;
+    pub fn H5Pset_sieve_buf_size(fapl_id: hid_t, size: size_t) -> herr_t;
+    pub fn H5Pget_sieve_buf_size(fapl_id: hid_t, size: *mut size_t/*out*/) -> herr_t;
+    pub fn H5Pset_small_data_block_size(fapl_id: hid_t, size: hsize_t) -> herr_t;
+    pub fn H5Pget_small_data_block_size(fapl_id: hid_t, size: *mut hsize_t/*out*/) -> herr_t;
+    pub fn H5Pset_libver_bounds(plist_id: hid_t, low: H5F_libver_t, high: H5F_libver_t) -> herr_t;
+    pub fn H5Pget_libver_bounds(plist_id: hid_t, low: *mut H5F_libver_t, high: *mut H5F_libver_t) -> herr_t;
+    pub fn H5Pset_elink_file_cache_size(plist_id: hid_t, efc_size: c_uint) -> herr_t;
+    pub fn H5Pget_elink_file_cache_size(plist_id: hid_t, efc_size: *mut c_uint) -> herr_t;
+    pub fn H5Pset_file_image(fapl_id: hid_t, buf_ptr: *const c_void, buf_len: size_t) -> herr_t;
+    pub fn H5Pget_file_image(fapl_id: hid_t, buf_ptr_ptr: *mut *const c_void, buf_len_ptr: *mut size_t) -> herr_t;
+    pub fn H5Pset_file_image_callbacks(fapl_id: hid_t, callbacks_ptr: *const H5FD_file_image_callbacks_t) -> herr_t;
+    pub fn H5Pget_file_image_callbacks(fapl_id: hid_t, callbacks_ptr: *mut H5FD_file_image_callbacks_t) -> herr_t;
+    pub fn H5Pset_core_write_tracking(fapl_id: hid_t, is_enabled: hbool_t, page_size: size_t) -> herr_t;
+    pub fn H5Pget_core_write_tracking(fapl_id: hid_t, is_enabled: *mut hbool_t, page_size: *mut size_t) -> herr_t;
+    pub fn H5Pset_layout(plist_id: hid_t, layout: H5D_layout_t) -> herr_t;
+    pub fn H5Pget_layout(plist_id: hid_t) -> H5D_layout_t;
+    pub fn H5Pset_chunk(plist_id: hid_t, ndims: c_int, dim: *const hsize_t) -> herr_t;
+    pub fn H5Pget_chunk(plist_id: hid_t, max_ndims: c_int, dim: *mut hsize_t/*out*/) -> c_int;
+    pub fn H5Pset_external(plist_id: hid_t, name: *const c_char, offset: off_t, size: hsize_t) -> herr_t;
+    pub fn H5Pget_external_count(plist_id: hid_t) -> c_int;
+    pub fn H5Pget_external(plist_id: hid_t, idx: c_uint, name_size: size_t, name: *mut c_char/*out*/,
+                           offset: *mut off_t/*out*/, size: *mut hsize_t/*out*/) -> herr_t;
+    pub fn H5Pset_szip(plist_id: hid_t, options_mask: c_uint, pixels_per_block: c_uint) -> herr_t;
+    pub fn H5Pset_shuffle(plist_id: hid_t) -> herr_t;
+    pub fn H5Pset_nbit(plist_id: hid_t) -> herr_t;
+    pub fn H5Pset_scaleoffset(plist_id: hid_t, scale_type: H5Z_SO_scale_type_t, scale_factor: c_int) -> herr_t;
+    pub fn H5Pset_fill_value(plist_id: hid_t, type_id: hid_t, value: *const c_void) -> herr_t;
+    pub fn H5Pget_fill_value(plist_id: hid_t, type_id: hid_t, value: *mut c_void/*out*/) -> herr_t;
+    pub fn H5Pfill_value_defined(plist: hid_t, status: *mut H5D_fill_value_t) -> herr_t;
+    pub fn H5Pset_alloc_time(plist_id: hid_t, alloc_time: H5D_alloc_time_t) -> herr_t;
+    pub fn H5Pget_alloc_time(plist_id: hid_t, alloc_time: *mut H5D_alloc_time_t/*out*/) -> herr_t;
+    pub fn H5Pset_fill_time(plist_id: hid_t, fill_time: H5D_fill_time_t) -> herr_t;
+    pub fn H5Pget_fill_time(plist_id: hid_t, fill_time: *mut H5D_fill_time_t/*out*/) -> herr_t;
+    pub fn H5Pset_chunk_cache(dapl_id: hid_t, rdcc_nslots: size_t, rdcc_nbytes: size_t, rdcc_w0: c_double) -> herr_t;
+    pub fn H5Pget_chunk_cache(dapl_id: hid_t, rdcc_nslots: *mut size_t/*out*/, rdcc_nbytes: *mut size_t/*out*/,
+                              rdcc_w0: *mut c_double/*out*/) -> herr_t;
+    pub fn H5Pset_data_transform(plist_id: hid_t, expression: *const c_char) -> herr_t;
+    pub fn H5Pget_data_transform(plist_id: hid_t, expression: *mut c_char/*out*/, size: size_t) -> ssize_t;
+    pub fn H5Pset_buffer(plist_id: hid_t, size: size_t, tconv: *const c_void, bkg: *const c_void) -> herr_t;
+    pub fn H5Pget_buffer(plist_id: hid_t, tconv: *mut *const c_void/*out*/, bkg: *mut *const c_void/*out*/) -> size_t;
+    pub fn H5Pset_preserve(plist_id: hid_t, status: hbool_t) -> herr_t;
+    pub fn H5Pget_preserve(plist_id: hid_t) -> c_int;
+    pub fn H5Pset_edc_check(plist_id: hid_t, check: H5Z_EDC_t) -> herr_t;
+    pub fn H5Pget_edc_check(plist_id: hid_t) -> H5Z_EDC_t;
+    pub fn H5Pset_filter_callback(plist_id: hid_t, func: H5Z_filter_func_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Pset_btree_ratios(plist_id: hid_t, left: c_double, middle: c_double, right: c_double) -> herr_t;
+    pub fn H5Pget_btree_ratios(plist_id: hid_t, left: *mut c_double/*out*/, middle: *mut c_double/*out*/,
+                               right: *mut c_double/*out*/) -> herr_t;
+    pub fn H5Pset_vlen_mem_manager(plist_id: hid_t, alloc_func: H5MM_allocate_t, alloc_info: *const c_void,
+                                   free_func: H5MM_free_t, free_info: *const c_void) -> herr_t;
+    pub fn H5Pget_vlen_mem_manager(plist_id: hid_t,alloc_func: *mut H5MM_allocate_t,
+                                   alloc_info: *mut *const c_void,
+                                   free_func: *mut H5MM_free_t, free_info: *mut *const c_void) -> herr_t;
+    pub fn H5Pset_hyper_vector_size(fapl_id: hid_t, size: size_t) -> herr_t;
+    pub fn H5Pget_hyper_vector_size(fapl_id: hid_t, size: *mut size_t/*out*/) -> herr_t;
+    pub fn H5Pset_type_conv_cb(dxpl_id: hid_t, op: H5T_conv_except_func_t,
+                               operate_data: *const c_void) -> herr_t;
+    pub fn H5Pget_type_conv_cb(dxpl_id: hid_t, op: *mut H5T_conv_except_func_t,
+                               operate_data: *mut *const c_void) -> herr_t;
+    pub fn H5Pget_mpio_actual_chunk_opt_mode(plist_id: hid_t,
+                                             actual_chunk_opt_mode: *mut H5D_mpio_actual_chunk_opt_mode_t) -> herr_t;
+    pub fn H5Pget_mpio_actual_io_mode(plist_id: hid_t,
+                                      actual_io_mode: *mut H5D_mpio_actual_io_mode_t) -> herr_t;
+    pub fn H5Pget_mpio_no_collective_cause(plist_id: hid_t, local_no_collective_cause: *mut u32,
+                                           global_no_collective_cause: *mut u32) -> herr_t;
+    pub fn H5Pset_create_intermediate_group(plist_id: hid_t, crt_intmd: c_uint) -> herr_t;
+    pub fn H5Pget_create_intermediate_group(plist_id: hid_t, crt_intmd: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pset_local_heap_size_hint(plist_id: hid_t, size_hint: size_t) -> herr_t;
+    pub fn H5Pget_local_heap_size_hint(plist_id: hid_t, size_hint: *mut size_t/*out*/) -> herr_t;
+    pub fn H5Pset_link_phase_change(plist_id: hid_t, max_compact: c_uint, min_dense: c_uint) -> herr_t;
+    pub fn H5Pget_link_phase_change(plist_id: hid_t, max_compact: *mut c_uint/*out*/,
+                                    min_dense: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Pset_est_link_info(plist_id: hid_t, est_num_entries: c_uint,
+                                est_name_len: c_uint) -> herr_t;
+    pub fn H5Pget_est_link_info(plist_id: hid_t, est_num_entries: *mut c_uint/* out */,
+                                est_name_len: *mut c_uint/* out */) -> herr_t;
+    pub fn H5Pset_link_creation_order(plist_id: hid_t, crt_order_flags: c_uint) -> herr_t;
+    pub fn H5Pget_link_creation_order(plist_id: hid_t, crt_order_flags: *mut c_uint/* out */) -> herr_t;
+    pub fn H5Pset_char_encoding(plist_id: hid_t, encoding: H5T_cset_t) -> herr_t;
+    pub fn H5Pget_char_encoding(plist_id: hid_t, encoding: *mut H5T_cset_t/*out*/) -> herr_t;
+    pub fn H5Pset_nlinks(plist_id: hid_t, nlinks: size_t) -> herr_t;
+    pub fn H5Pget_nlinks(plist_id: hid_t, nlinks: *mut size_t) -> herr_t;
+    pub fn H5Pset_elink_prefix(plist_id: hid_t, prefix: *const c_char) -> herr_t;
+    pub fn H5Pget_elink_prefix(plist_id: hid_t, prefix: *mut c_char, size: size_t) -> ssize_t;
+    pub fn H5Pget_elink_fapl(lapl_id: hid_t) -> hid_t;
+    pub fn H5Pset_elink_fapl(lapl_id: hid_t, fapl_id: hid_t) -> herr_t;
+    pub fn H5Pset_elink_acc_flags(lapl_id: hid_t, flags: c_uint) -> herr_t;
+    pub fn H5Pget_elink_acc_flags(lapl_id: hid_t, flags: *mut c_uint) -> herr_t;
+    pub fn H5Pset_elink_cb(lapl_id: hid_t, func: H5L_elink_traverse_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Pget_elink_cb(lapl_id: hid_t, func: *mut H5L_elink_traverse_t, op_data: *mut *const c_void) -> herr_t;
+    pub fn H5Pset_copy_object(plist_id: hid_t, crt_intmd: c_uint) -> herr_t;
+    pub fn H5Pget_copy_object(plist_id: hid_t, crt_intmd: *mut c_uint/*out*/) -> herr_t;
+    pub fn H5Padd_merge_committed_dtype_path(plist_id: hid_t, path: *const c_char) -> herr_t;
+    pub fn H5Pfree_merge_committed_dtype_paths(plist_id: hid_t) -> herr_t;
+    pub fn H5Pset_mcdt_search_cb(plist_id: hid_t, func: H5O_mcdt_search_cb_t, op_data: *const c_void) -> herr_t;
+    pub fn H5Pget_mcdt_search_cb(plist_id: hid_t, func: *mut H5O_mcdt_search_cb_t,
+                                 op_data: *mut *const c_void) -> herr_t;
+}

--- a/src/H5Rpublic.rs
+++ b/src/H5Rpublic.rs
@@ -1,0 +1,27 @@
+use libc::{c_char, c_void, size_t, ssize_t};
+use H5Ipublic::hid_t;
+use H5public::herr_t;
+use H5Opublic::H5O_type_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5R_type_t {
+    H5R_BADTYPE = (-1),
+    H5R_OBJECT,
+    H5R_DATASET_REGION,
+    H5R_MAXTYPE,
+}
+
+extern "C" {
+    pub fn H5Rcreate(reference: *mut c_void, loc_id: hid_t, name: *const c_char,
+                     ref_type: H5R_type_t, space_id: hid_t) -> herr_t;
+    pub fn H5Rdereference(obj_id: hid_t, ref_type: H5R_type_t,
+                          reference: *const c_void) -> hid_t;
+    pub fn H5Rget_obj_type2(loc_id: hid_t, ref_type: H5R_type_t,
+                            reference: *const c_void, obj_type: *mut H5O_type_t) -> herr_t;
+    pub fn H5Rget_region(loc_id: hid_t, ref_type: H5R_type_t,
+                         reference: *const c_void) -> hid_t;
+    pub fn H5Rget_name(loc_id: hid_t, ref_type: H5R_type_t,
+                       reference: *const c_void, name: *mut c_char, size: size_t) -> ssize_t;
+}
+

--- a/src/H5Spublic.rs
+++ b/src/H5Spublic.rs
@@ -1,10 +1,20 @@
-use libc::c_int;
+use libc::{c_int, c_uchar, size_t};
 
 use H5Ipublic::hid_t;
-use H5public::{herr_t, hsize_t, hssize_t};
+use H5public::{herr_t, hsize_t, htri_t, hssize_t};
 
 pub const H5S_ALL: hid_t = 0;
 pub const H5S_UNLIMITED: hsize_t = (-1 as hssize_t) as hsize_t;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5S_class_t {
+    H5S_NO_CLASS = -1,
+    H5S_SCALAR = 0,
+    H5S_SIMPLE = 1,
+    H5S_NULL = 2,
+}
+pub use self::H5S_class_t::*;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
@@ -22,15 +32,51 @@ pub enum H5S_seloper_t {
 }
 pub use self::H5S_seloper_t::*;
 
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5S_sel_type {
+    H5S_SEL_ERROR = -1,
+    H5S_SEL_NONE = 0,
+    H5S_SEL_POINTS = 1,
+    H5S_SEL_HYPERSLABS = 2,
+    H5S_SEL_ALL = 3,
+    H5S_SEL_N,
+}
+pub use self::H5S_sel_type::*;
+
 extern "C" {
+    pub fn H5Screate(dataspace_type: H5S_class_t) -> hid_t;
+    pub fn H5Scopy(space_id: hid_t) -> hid_t;
+    pub fn H5Sclose(space_id: hid_t) -> herr_t;
+    pub fn H5Sdecode(buf: *const c_uchar) -> hid_t;
+    pub fn H5Sencode(obj_id: hid_t, buf: *mut c_uchar, nalloc: *mut size_t) -> herr_t;
     pub fn H5Screate_simple(rank: c_int, current_dims: *const hsize_t,
                             maximum_dims: *const hsize_t) -> hid_t;
-
+    pub fn H5Sis_simple(space_id: hid_t) -> htri_t;
+    pub fn H5Soffset_simple(space_id: hid_t, offset: *const hssize_t) -> herr_t;
+    pub fn H5Sget_simple_extent_dims(space_id: hid_t, dims: *mut hsize_t, maxdims: *mut hsize_t) -> c_int;
+    pub fn H5Sget_simple_extent_ndims(space_id: hid_t) -> c_int;
+    pub fn H5Sget_simple_extent_npoints(space_id: hid_t) -> hssize_t;
+    pub fn H5Sget_simple_extent_type(space_id: hid_t) -> H5S_class_t;
+    pub fn H5Sextent_copy(dest_space_id: hid_t, source_space_id: hid_t) -> herr_t;
+    pub fn H5Sextent_equal(space1_id: hid_t, space2_id: hid_t) -> htri_t;
     pub fn H5Sset_extent_simple(space_id: hid_t, rank: c_int, dims: *const hsize_t,
                                 max: *const hsize_t) -> herr_t;
-
-    pub fn H5Sclose(space_id: hid_t) -> herr_t;
-
+    pub fn H5Sset_extent_none(space_id: hid_t) -> herr_t;
+    pub fn H5Sget_select_type(space_id: hid_t) -> H5S_sel_type;
+    pub fn H5Sget_select_npoints(space_id: hid_t) -> hssize_t;
+    pub fn H5Sget_select_hyper_nblocks(space_id: hid_t) -> hssize_t;
+    pub fn H5Sget_select_hyper_blocklist(space_id: hid_t, startblock: hsize_t,
+                                         numblocks: hsize_t, buf: *mut hsize_t) -> herr_t;
+    pub fn H5Sget_select_elem_npoints(space_id: hid_t) -> hssize_t;
+    pub fn H5Sget_select_elem_pointlist(space_id: hid_t, startpoint: hsize_t,
+                                        numpoints: hsize_t, buf: *mut hsize_t) -> herr_t;
+    pub fn H5Sget_select_bounds(space_id: hid_t, start: *mut hsize_t, end: *mut hsize_t) -> herr_t;
+    pub fn H5Sselect_elements(space_id: hid_t, op: H5S_seloper_t, num_elements: size_t,
+                              coord: *const hsize_t) -> herr_t;
+    pub fn H5Sselect_all(dspace_id: hid_t) -> herr_t;
+    pub fn H5Sselect_none(space_id: hid_t) -> herr_t;
+    pub fn H5Sselect_valid(space_id: hid_t) -> htri_t;
     pub fn H5Sselect_hyperslab(space_id: hid_t, op: H5S_seloper_t, start: *const hsize_t,
                                _stride: *const hsize_t, count: *const hsize_t,
                                _block: *const hsize_t) -> herr_t;

--- a/src/H5Tpublic.rs
+++ b/src/H5Tpublic.rs
@@ -1,7 +1,7 @@
-use libc::{c_char, c_uint, size_t};
+use libc::{c_char, c_int, c_uint, c_void, size_t};
 
 use H5Ipublic::hid_t;
-use H5public::{herr_t, hsize_t, htri_t};
+use H5public::{herr_t, hsize_t, htri_t, hbool_t};
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
@@ -18,10 +18,41 @@ pub enum H5T_class_t {
     H5T_ENUM = 8,
     H5T_VLEN = 9,
     H5T_ARRAY = 10,
-
     H5T_NCLASSES,
 }
 pub use self::H5T_class_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_order_t {
+    H5T_ORDER_ERROR = -1,
+    H5T_ORDER_LE = 0,
+    H5T_ORDER_BE = 1,
+    H5T_ORDER_VAX = 2,
+    H5T_ORDER_MIXED = 3,
+    H5T_ORDER_NONE = 4,
+}
+pub use self::H5T_order_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_sign_t {
+    H5T_SGN_ERROR = -1,
+    H5T_SGN_NONE = 0,
+    H5T_SGN_2 = 1,
+    H5T_NSGN = 2,
+}
+pub use self::H5T_sign_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_norm_t {
+    H5T_NORM_ERROR = -1,
+    H5T_NORM_IMPLIED = 0,
+    H5T_NORM_MSBSET = 1,
+    H5T_NORM_NONE = 2,
+}
+pub use self::H5T_norm_t::*;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
@@ -46,22 +77,108 @@ pub enum H5T_cset_t {
 }
 pub use self::H5T_cset_t::*;
 
-extern "C" {
-    pub fn H5Tcreate(typo: H5T_class_t, size: size_t) -> hid_t;
-    pub fn H5Tcopy(type_id: hid_t) -> hid_t;
-    pub fn H5Tclose(type_id: hid_t) -> herr_t;
-    pub fn H5Tequal(type1_id: hid_t, type2_id: hid_t) -> htri_t;
-
-    pub fn H5Tinsert(parent_id: hid_t, name: *const c_char, offset: size_t, member_id: hid_t)
-                     -> herr_t;
-
-    pub fn H5Tvlen_create(base_id: hid_t) -> hid_t;
-    pub fn H5Tarray_create2(base_id: hid_t, ndims: c_uint, dim: *const hsize_t) -> hid_t;
-    pub fn H5Tget_size(type_id: hid_t) -> size_t;
-    pub fn H5Tget_cset(type_id: hid_t) -> H5T_cset_t;
-    pub fn H5Tset_size(type_id: hid_t, size: size_t) -> herr_t;
-    pub fn H5Tset_cset(type_id: hid_t, cset: H5T_cset_t) -> herr_t;
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_str_t {
+    H5T_STR_ERROR = -1,
+    H5T_STR_NULLTERM = 0,
+    H5T_STR_NULLPAD = 1,
+    H5T_STR_SPACEPAD = 2,
+    H5T_STR_RESERVED_3 = 3,
+    H5T_STR_RESERVED_4 = 4,
+    H5T_STR_RESERVED_5 = 5,
+    H5T_STR_RESERVED_6 = 6,
+    H5T_STR_RESERVED_7 = 7,
+    H5T_STR_RESERVED_8 = 8,
+    H5T_STR_RESERVED_9 = 9,
+    H5T_STR_RESERVED_10 = 10,
+    H5T_STR_RESERVED_11 = 11,
+    H5T_STR_RESERVED_12 = 12,
+    H5T_STR_RESERVED_13 = 13,
+    H5T_STR_RESERVED_14 = 14,
+    H5T_STR_RESERVED_15 = 15,
 }
+pub use self::H5T_str_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_pad_t {
+    H5T_PAD_ERROR = -1,
+    H5T_PAD_ZERO = 0,
+    H5T_PAD_ONE = 1,
+    H5T_PAD_BACKGROUND = 2,
+    H5T_NPAD = 3,
+}
+pub use self::H5T_pad_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_cmd_t {
+    H5T_CONV_INIT = 0,
+    H5T_CONV_CONV = 1,
+    H5T_CONV_FREE = 2,
+}
+pub use self::H5T_cmd_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_bkg_t {
+    H5T_BKG_NO = 0,
+    H5T_BKG_TEMP = 1,
+    H5T_BKG_YES = 2,
+}
+pub use self::H5T_bkg_t::*;
+
+#[repr(C)]
+pub struct H5T_cdata_t {
+    command: H5T_cmd_t,
+    need_bkg: H5T_bkg_t,
+    recalc: hbool_t,
+    priv_data: *const c_void,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_pers_t {
+    H5T_PERS_DONTCARE = -1,
+    H5T_PERS_HARD = 0,
+    H5T_PERS_SOFT = 1,
+}
+pub use self::H5T_pers_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_direction_t {
+    H5T_DIR_DEFAULT = 0,
+    H5T_DIR_ASCEND = 1,
+    H5T_DIR_DESCEND = 2,
+}
+pub use self::H5T_direction_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_conv_except_t {
+    H5T_CONV_EXCEPT_RANGE_HI = 0,
+    H5T_CONV_EXCEPT_RANGE_LOW = 1,
+    H5T_CONV_EXCEPT_PRECISION = 2,
+    H5T_CONV_EXCEPT_TRUNCATE = 3,
+    H5T_CONV_EXCEPT_PINF = 4,
+    H5T_CONV_EXCEPT_NINF = 5,
+    H5T_CONV_EXCEPT_NAN = 6,
+}
+pub use self::H5T_conv_except_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5T_conv_ret_t {
+    H5T_CONV_ABORT = -1,
+    H5T_CONV_UNHANDLED = 0,
+    H5T_CONV_HANDLED = 1,
+}
+pub use self::H5T_conv_ret_t::*;
+
+pub type H5T_conv_t = extern fn(hid_t, hid_t, *mut H5T_cdata_t, size_t, size_t, size_t, *mut c_void, *mut c_void, hid_t) -> herr_t;
+pub type H5T_conv_except_func_t = extern fn(H5T_conv_except_t, hid_t, hid_t, *mut c_void, *mut c_void, *mut c_void) -> H5T_conv_ret_t;
 
 extern "C" {
     pub static H5T_C_S1_g: hid_t;
@@ -88,3 +205,78 @@ pub use self::H5T_NATIVE_INT32_g as H5T_NATIVE_INT32;
 pub use self::H5T_NATIVE_UINT32_g as H5T_NATIVE_UINT32;
 pub use self::H5T_NATIVE_INT64_g as H5T_NATIVE_INT64;
 pub use self::H5T_NATIVE_UINT64_g as H5T_NATIVE_UINT64;
+
+extern "C" {
+    pub fn H5Tcreate(dtype: H5T_class_t, size: size_t) -> hid_t;
+    pub fn H5Tcopy(dtype_id: hid_t) -> hid_t;
+    pub fn H5Tclose(dtype_id: hid_t) -> herr_t;
+    pub fn H5Tequal(dtype1_id: hid_t, dtype2_id: hid_t) -> htri_t;
+    pub fn H5Tlock(dtype_id: hid_t) -> herr_t;
+    pub fn H5Tcommit2(loc_id: hid_t, name: *const c_char, dtype_id: hid_t, lcpl_id: hid_t,
+                      tcpl_id: hid_t, tapl_id: hid_t) -> herr_t;
+    pub fn H5Topen2(loc_id: hid_t, name: *const c_char, tapl_id: hid_t) -> hid_t;
+    pub fn H5Tcommit_anon(loc_id: hid_t, dtype_id: hid_t, tcpl_id: hid_t, tapl_id: hid_t) -> herr_t;
+    pub fn H5Tget_create_plist(dtype_id: hid_t) -> hid_t;
+    pub fn H5Tcommitted(dtype_id: hid_t) -> htri_t;
+    pub fn H5Tencode(obj_id: hid_t, buf: *mut c_void, nalloc: *mut size_t) -> herr_t;
+    pub fn H5Tdecode(buf: *const c_void) -> hid_t;
+    pub fn H5Tinsert(parent_id: hid_t, name: *const c_char, offset: size_t, member_id: hid_t) -> herr_t;
+    pub fn H5Tpack(dtype_id: hid_t) -> herr_t;
+    pub fn H5Tenum_create(base_id: hid_t) -> hid_t;
+    pub fn H5Tenum_insert(dtype: hid_t, name: *const c_char, value: *const c_void) -> herr_t;
+    pub fn H5Tenum_nameof(dtype: hid_t, value: *const c_void, name: *mut c_char/*out*/, size: size_t) -> herr_t;
+    pub fn H5Tenum_valueof(dtype: hid_t, name: *const c_char, value: *mut c_void/*out*/) -> herr_t;
+    pub fn H5Tvlen_create(base_id: hid_t) -> hid_t;
+    pub fn H5Tarray_create2(base_id: hid_t, ndims: c_uint, dim: *const hsize_t) -> hid_t;
+    pub fn H5Tget_array_ndims(dtype_id: hid_t) -> c_int;
+    pub fn H5Tget_array_dims2(dtype_id: hid_t, dims: *mut hsize_t) -> c_int;
+    pub fn H5Tset_tag(dtype: hid_t, tag: *const c_char) -> herr_t;
+    pub fn H5Tget_tag(dtype: hid_t) -> *const c_char;
+    pub fn H5Tget_super(dtype: hid_t) -> hid_t;
+    pub fn H5Tget_class(dtype_id: hid_t) -> H5T_class_t;
+    pub fn H5Tdetect_class(dtype_id: hid_t, cls: H5T_class_t) -> htri_t;
+    pub fn H5Tget_size(dtype_id: hid_t) -> size_t;
+    pub fn H5Tget_order(dtype_id: hid_t) -> H5T_order_t;
+    pub fn H5Tget_precision(dtype_id: hid_t) -> size_t;
+    pub fn H5Tget_offset(dtype_id: hid_t) -> c_int;
+    pub fn H5Tget_pad(dtype_id: hid_t, lsb: *mut H5T_pad_t/*out*/, msb: *mut H5T_pad_t/*out*/) -> herr_t;
+    pub fn H5Tget_sign(dtype_id: hid_t) -> H5T_sign_t;
+    pub fn H5Tget_fields(dtype_id: hid_t, spos: *mut size_t/*out*/, epos: *mut size_t/*out*/,
+                         esize: *mut size_t/*out*/, mpos: *mut size_t/*out*/,
+                         msize: *mut size_t/*out*/) -> herr_t;
+    pub fn H5Tget_ebias(dtype_id: hid_t) -> size_t;
+    pub fn H5Tget_norm(dtype_id: hid_t) -> H5T_norm_t;
+    pub fn H5Tget_inpad(dtype_id: hid_t) -> H5T_pad_t;
+    pub fn H5Tget_strpad(dtype_id: hid_t) -> H5T_str_t;
+    pub fn H5Tget_nmembers(dtype_id: hid_t) -> c_int;
+    pub fn H5Tget_member_name(dtype_id: hid_t, membno: c_uint) -> *const c_char;
+    pub fn H5Tget_member_index(dtype_id: hid_t, name: *const c_char) -> c_int;
+    pub fn H5Tget_member_offset(dtype_id: hid_t, membno: c_uint) -> size_t;
+    pub fn H5Tget_member_class(dtype_id: hid_t, membno: c_uint) -> H5T_class_t;
+    pub fn H5Tget_member_dtype(dtype_id: hid_t, membno: c_uint) -> hid_t;
+    pub fn H5Tget_member_value(dtype_id: hid_t, membno: c_uint, value: *mut c_void/*out*/) -> herr_t;
+    pub fn H5Tget_cset(dtype_id: hid_t) -> H5T_cset_t;
+    pub fn H5Tis_variable_str(dtype_id: hid_t) -> htri_t;
+    pub fn H5Tget_native_dtype(dtype_id: hid_t, direction: H5T_direction_t) -> hid_t;
+    pub fn H5Tset_size(dtype_id: hid_t, size: size_t) -> herr_t;
+    pub fn H5Tset_order(dtype_id: hid_t, order: H5T_order_t) -> herr_t;
+    pub fn H5Tset_precision(dtype_id: hid_t, prec: size_t) -> herr_t;
+    pub fn H5Tset_offset(dtype_id: hid_t, offset: size_t) -> herr_t;
+    pub fn H5Tset_pad(dtype_id: hid_t, lsb: H5T_pad_t, msb: H5T_pad_t) -> herr_t;
+    pub fn H5Tset_sign(dtype_id: hid_t, sign: H5T_sign_t) -> herr_t;
+    pub fn H5Tset_fields(dtype_id: hid_t, spos: size_t, epos: size_t, esize: size_t,
+                         mpos: size_t, msize: size_t) -> herr_t;
+    pub fn H5Tset_ebias(dtype_id: hid_t, ebias: size_t) -> herr_t;
+    pub fn H5Tset_norm(dtype_id: hid_t, norm: H5T_norm_t) -> herr_t;
+    pub fn H5Tset_inpad(dtype_id: hid_t, pad: H5T_pad_t) -> herr_t;
+    pub fn H5Tset_cset(dtype_id: hid_t, cset: H5T_cset_t) -> herr_t;
+    pub fn H5Tset_strpad(dtype_id: hid_t, strpad: H5T_str_t) -> herr_t;
+    pub fn H5Tregister(pers: H5T_pers_t, name: *const c_char, src_id: hid_t,
+                       dst_id: hid_t, func: H5T_conv_t) -> herr_t;
+    pub fn H5Tunregister(pers: H5T_pers_t, name: *const c_char, src_id: hid_t,
+                         dst_id: hid_t, func: H5T_conv_t) -> herr_t;
+    pub fn H5Tfind(src_id: hid_t, dst_id: hid_t, pcdata: *mut *const H5T_cdata_t) -> H5T_conv_t;
+    pub fn H5Tcompiler_conv(src_id: hid_t, dst_id: hid_t) -> htri_t;
+    pub fn H5Tconvert(src_id: hid_t, dst_id: hid_t, nelmts: size_t, buf: *mut c_void,
+                      background: *const c_void, plist_id: hid_t) -> herr_t;
+}

--- a/src/H5Zpublic.rs
+++ b/src/H5Zpublic.rs
@@ -1,0 +1,49 @@
+use libc::{c_int, c_uint, c_void, size_t};
+use H5public::{herr_t, htri_t};
+
+pub type H5Z_filter_t = c_int;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5Z_SO_scale_type_t {
+    H5Z_SO_FLOAT_DSCALE = 0,
+    H5Z_SO_FLOAT_ESCALE = 1,
+    H5Z_SO_INT = 2,
+}
+pub use self::H5Z_SO_scale_type_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5Z_EDC_t {
+    H5Z_ERROR_EDC = -1,
+    H5Z_DISABLE_EDC = 0,
+    H5Z_ENABLE_EDC = 1,
+    H5Z_NO_EDC = 2,
+}
+pub use self::H5Z_EDC_t::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub enum H5Z_cb_return_t {
+    H5Z_CB_ERROR = -1,
+    H5Z_CB_FAIL = 0,
+    H5Z_CB_CONT = 1,
+    H5Z_CB_NO = 2,
+}
+pub use self::H5Z_cb_return_t::*;
+
+pub type H5Z_filter_func_t = extern fn(H5Z_filter_t,*mut c_void,
+                                       size_t, *mut c_void) -> H5Z_cb_return_t;
+
+#[repr(C)]
+pub struct H5Z_cb_t {
+    func: H5Z_filter_func_t,
+    op_data: *const c_void,
+}
+
+extern "C" {
+    pub fn H5Zregister(cls: *const c_void) -> herr_t;
+    pub fn H5Zunregister(id: H5Z_filter_t) -> herr_t;
+    pub fn H5Zfilter_avail(id: H5Z_filter_t) -> htri_t;
+    pub fn H5Zget_filter_info(filter: H5Z_filter_t, filter_config_flags: *mut c_uint) -> herr_t;
+}

--- a/src/H5public.rs
+++ b/src/H5public.rs
@@ -1,11 +1,51 @@
-use libc::{c_int, c_longlong, c_uint, c_ulonglong};
+use libc::{c_int, c_longlong, c_uint, c_ulonglong, c_void, size_t};
 
 pub type herr_t = c_int;
 pub type htri_t = c_int;
 pub type hsize_t = c_ulonglong;
 pub type hssize_t = c_longlong;
+pub type hbool_t = c_uint;
+
+#[cfg(target_pointer_width = "32")]
+pub type haddr_t = u32;
+#[cfg(target_pointer_width = "64")]
+pub type haddr_t = u64;
+
+#[repr(C)]
+pub enum H5_iter_order_t {
+    H5_ITER_UNKNOWN = -1,
+    H5_ITER_INC,
+    H5_ITER_DEC,
+    H5_ITER_NATIVE,
+    H5_ITER_N,
+}
+pub use self::H5_iter_order_t::*;
+
+#[repr(C)]
+pub enum H5_index_t {
+    H5_INDEX_UNKNOWN = -1,
+    H5_INDEX_NAME,
+    H5_INDEX_CRT_ORDER,
+    H5_INDEX_N,
+}
+pub use self::H5_index_t::*;
+
+#[repr(C)]
+pub struct H5_ih_info_t {
+    index_size: hsize_t,
+    heap_size: hsize_t,
+}
 
 extern "C" {
+    pub fn H5open() -> herr_t;
+    pub fn H5dont_atexit() -> herr_t;
+    pub fn H5set_free_list_limits(reg_global_lim: c_int, reg_list_lim: c_int, arr_global_lim: c_int, arr_list_lim: c_int, blk_global_lim: c_int, blk_list_lim: c_int) -> herr_t;
+    pub fn H5garbage_collect() -> herr_t;
+    pub fn H5allocate_memory(size: size_t, clear: hbool_t) -> *mut c_void;
+    pub fn H5resize_memory(mem: *mut c_void, size: size_t ) -> *mut c_void;
+    pub fn H5free_memory(buf: *mut c_void) -> herr_t;
     pub fn H5get_libversion(majnum: *mut c_uint, minnum: *mut c_uint, relnum: *mut c_uint)
                             -> herr_t;
+    pub fn H5check_version(majnum: c_uint, minnum: c_uint, relnum: c_uint) -> herr_t;
+    pub fn H5is_library_threadsafe(is_ts: *mut hbool_t) -> herr_t;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,38 @@
-#![allow(non_camel_case_types, non_snake_case)]
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
 
 extern crate libc;
 
+mod H5Apublic;
+mod H5Cpublic;
 mod H5Dpublic;
+mod H5Epublic;
 mod H5Fpublic;
+mod H5Gpublic;
 mod H5Ipublic;
 mod H5Lpublic;
+mod H5Opublic;
 mod H5Ppublic;
+mod H5Rpublic;
 mod H5Spublic;
 mod H5Tpublic;
+mod H5Zpublic;
+mod H5ACpublic;
+mod H5FDpublic;
+mod H5MMpublic;
+mod H5PLpublic;
 mod H5public;
 
+pub use H5Cpublic::*;
 pub use H5Dpublic::*;
 pub use H5Fpublic::*;
+pub use H5Gpublic::*;
 pub use H5Ipublic::*;
 pub use H5Lpublic::*;
 pub use H5Ppublic::*;
 pub use H5Spublic::*;
 pub use H5Tpublic::*;
+pub use H5Epublic::*;
+pub use H5ACpublic::*;
 pub use H5public::*;
 
 #[cfg(test)]
@@ -26,6 +41,6 @@ mod tests {
     fn link() {
         let (mut majnum, mut minnum, mut relnum) = (0, 0, 0);
         assert!(unsafe { ::H5get_libversion(&mut majnum, &mut minnum, &mut relnum) } >= 0);
-        assert_eq!((majnum, minnum, relnum), (1, 8, 15));
+        assert_eq!((majnum, minnum), (1, 8));
     }
 }


### PR DESCRIPTION
I have been working on adding HDF5 support to my package [numeric](https://github.com/gustavla/numeric), and for what I was doing it was easier to tap into hdf5-sys directly instead of hdf5 (partly because it is incomplete). I ended up adding function after function to hdf5-sys since many were missing there as well, so my local version started growing. I decided to just go through and add most of them so that you can hopefully push it out as a version soon (and I can thus start releasing my new version of numeric).

A lot of it is of course untested and I guarantee that things will need to be fixed here and there. Again, I also do not claim this covers everything, but it will hopefully bring it above the 90% mark.

Original commit message:
- Still missing modules: H5DS, H5IM, H5LT, H5PT, H5TB
- There could still be missing functions, enums and structs and plenty
  of testing will be necessary.
- Sometimes the choice between mut/const were arbitrary. Mostly I
  followed the documentation and if it stated "OUT:" I made it mutable.
- I have skipped deprecated functions.
