### PR TITLE
Minor typos fixed (resolves `cargo doc` crash)

### DIFF
--- a/src/H5Opublic.rs
+++ b/src/H5Opublic.rs
@@ -71,7 +71,7 @@ pub enum H5O_mcdt_search_ret_t {
     H5O_MCDT_SEARCH_CONT,
     H5O_MCDT_SEARCH_STOP,
 }
-pub use self::H5O_mcdt_search_cb_t::*;
+pub use self::H5O_mcdt_search_ret_t::*;
 
 pub type H5O_mcdt_search_cb_t = extern "C" fn(*mut c_void) -> H5O_mcdt_search_ret_t;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub use H5Fpublic::*;
 pub use H5Gpublic::*;
 pub use H5Ipublic::*;
 pub use H5Lpublic::*;
+pub use H5MMpublic::*;
 pub use H5Opublic::*;
 pub use H5PLpublic::*;
 pub use H5Ppublic::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types, non_snake_case)]
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
 
 extern crate libc;
 


### PR DESCRIPTION
I noticed that my previous PR (#1) actually broke `cargo doc`, and it turned out it was a typo in a `pub use self::abc::*` statement. Instead of the enum, I was by accident trying to lift a function pointer out, and that crashed `cargo doc`. It's particularly bad since it will also break `cargo doc` for other projects that depend on this, unless they use `--no-deps`.

I also silenced some more warnings and added a missing `pub use` line for H5MM. Perhaps I shouldn't have gathered these in the same PR, so let me know and I can rearrange if you want.

Also, thanks so much for how quickly you tidied up my last PR and pushed out a new version. Much appreciated! This one is not nearly as time-sensitive.
